### PR TITLE
Fix client test

### DIFF
--- a/integration/tests.go
+++ b/integration/tests.go
@@ -49,6 +49,9 @@ func (s *TestSuite) signCosmosRawTxn() error {
 // signRawRawTransaction just signs a txn with
 func (s *TestSuite) signEthereumRawTxn() error {
 	ethclient, err := ethclient.Dial(*s.rpcURL)
+	if err != nil {
+		return err
+	}
 	key, err := crypto.HexToECDSA(*s.pk)
 	if err != nil {
 		return err
@@ -159,7 +162,7 @@ func main() {
 	if err != nil {
 		panic("ERROR In creating new client: " + err.Error())
 	}
-	client.Start()
+	_ = client.Start()
 	reply, err := client.SendRawTransaction(testSuite.signedTransaction, testSuite.ticker)
 	if err != nil {
 		panic("ERROR Send raw transaction: " + err.Error())

--- a/minclient/pki.go
+++ b/minclient/pki.go
@@ -30,9 +30,9 @@ import (
 
 var (
 	errGetConsensusCanceled = errors.New("minclient/pki: consensus fetch canceled")
-	errConsensusNotFound    = errors.New("minclient/pki: consensus not ready yet")
-	nextFetchTill           = epochtime.Period / 8
-	recheckInterval         = 1 * time.Minute
+	// errConsensusNotFound    = errors.New("minclient/pki: consensus not ready yet")
+	nextFetchTill   = epochtime.Period / 8
+	recheckInterval = 1 * time.Minute
 	// WarpedEpoch is a build time flag that accelerates the recheckInterval
 	WarpedEpoch = "false"
 )

--- a/minclient/send.go
+++ b/minclient/send.go
@@ -151,7 +151,7 @@ func (c *Client) makePath(recipient, provider string, surbID *[sConstants.SURBID
 
 	p, t, err := path.New(c.rng, doc, []byte(recipient), src, dst, surbID, baseTime, true, isForward)
 	if err == nil {
-		c.logPath(doc, p)
+		_ = c.logPath(doc, p)
 	}
 
 	return p, t, err

--- a/queue_test.go
+++ b/queue_test.go
@@ -22,7 +22,7 @@ func TestQueue(t *testing.T) {
 	s, err := q.Pop()
 	assert.NoError(err)
 	assert.Equal(s.(foo).x, "hello")
-	s, err = q.Pop()
+	_, err = q.Pop()
 	assert.Error(err)
 
 	for i := 0; i < constants.MaxEgressQueueSize; i++ {


### PR DESCRIPTION
I always got this error when test the current client:

```
Error opening katzenmint-pki database: unknown db_backend badgerdb, expected one of goleveldb,memdb
```

That might be better if we use mock implementation in the client test, like what tendermint did:

https://github.com/tendermint/tendermint/blob/master/light/rpc/client_test.go

This PR aims at fixing the linter error (unchecked error and unused function) and mock the client test.